### PR TITLE
Fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
-sudo: false
+sudo: required
 language: ruby
 rvm:
   - 2.4.0
   - 2.3.3
   - 2.2.6
-  - 2.0.0
-before_install: gem install bundler
+before_install:
+  - gem install bundler

--- a/Rakefile
+++ b/Rakefile
@@ -3,4 +3,4 @@ require "rspec/core/rake_task"
 
 RSpec::Core::RakeTask.new(:spec)
 
-task :default => :spec
+task default: :spec

--- a/otpui.gemspec
+++ b/otpui.gemspec
@@ -27,4 +27,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "clipboard"
   spec.add_dependency "zxing"
   spec.add_dependency "uri-query_params"
+  spec.add_dependency "gio2", "< 3.1"
 end

--- a/spec/otpui_spec.rb
+++ b/spec/otpui_spec.rb
@@ -4,8 +4,4 @@ describe Otpui do
   it "has a version number" do
     expect(Otpui::VERSION).not_to be nil
   end
-
-  it "does something useful" do
-    expect(false).to eq(true)
-  end
 end


### PR DESCRIPTION
Locking `gio2` to 3.0.9 for now.

see https://github.com/ruby-gnome2/ruby-gnome2/issues/970